### PR TITLE
Restore functionality to AWAPer

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,7 @@ Authors@R: c(
 Maintainer: Tim Peterson <tim.peterson@monash.edu>
 Description: NetCDF files of the Bureau of Meteorology Australian Water Availability Project daily national climate grids are built and used for the efficient extraction of point and catchment area weighted precipitation, minimum temperature, maximum temperature, vapour pressure, solar radiation and various measures of evapotranspiration. For details on the source climate data see <http://www.bom.gov.au/jsp/awap/>.
 Depends: R (>= 3.5)
-Imports: Evapotranspiration (>= 1.14), ncdf4, utils, raster, chron, maptools, sp, zoo, methods, xts, stats
+Imports: Evapotranspiration (>= 1.14), ncdf4, utils, raster, chron, maptools, sp, zoo, methods, xts, stats, RCurl
 Suggests: knitr, rmarkdown
 VignetteBuilder: knitr
 BugReports: https://github.com/peterson-tim-j/AWAPer/issues

--- a/R/download.ASCII.file.R
+++ b/R/download.ASCII.file.R
@@ -32,15 +32,17 @@ download.ASCII.file <- function (url.string, data.type.label,  workingFolder, da
         }
       },
       error = function(cond) {
+        failureMessage <- cond
         return(TRUE)
       }
     )
     if (length(didFail) == 0) {didFail <- 0}
-    if (didFail==0) {
-
+    if (didFail == 0) {
+      
       displayErrorMessage <- function() {
         message('------------------------------------------------------------------------------------')
-        message('The program "7z" is either not installed or cannot be found. If not installed then')
+        message('If the below error is not obvious, it may be that the program "7z" is either not installed')
+        message('or cannot be found. If not installed then')
         message('install it from https://www.7-zip.org/download.html .')
         message('Once installed, do the following steps:')
         message('  1. Click "Search Windows", search "Edit environmental variables for your account" and click on it.')
@@ -51,7 +53,7 @@ download.ASCII.file <- function (url.string, data.type.label,  workingFolder, da
         message('  6. Open the "Command Prompt" and enter the command "7z".')
         message('     If setup correctly, this should output details such as the version, descriptions of commands, etc.')
         message('------------------------------------------------------------------------------------')
-        stop()
+        stop(failureMessage)
       }
 
       exitMessage = tryCatch(

--- a/R/download.ASCII.file.R
+++ b/R/download.ASCII.file.R
@@ -81,8 +81,11 @@ download.ASCII.file <- function (url.string, data.type.label,  workingFolder, da
     des.file.name = file.path(workingFolder,paste(data.type.label,datestring,'.grid.Z',sep=''))
     didFail = tryCatch(
       {
-        content <- RCurl::getBinaryURL(url, verbose=FALSE, .opts=list(useragent='Mozila 5.0'))
-        writeBin(content, des.file.name)
+        # only download the file if the .Z file isn't saved in the working directory
+        if (!file.exists(des.file.name)) {
+          content <- RCurl::getBinaryURL(url, verbose=FALSE, .opts=list(useragent='Mozila 5.0'))
+          writeBin(content, des.file.name)
+        }
       },
       error = function(cond) {
         return(TRUE)

--- a/R/download.ASCII.file.R
+++ b/R/download.ASCII.file.R
@@ -24,6 +24,19 @@ download.ASCII.file <- function (url.string, data.type.label,  workingFolder, da
   if (OS=='Windows') {
     des.file.name = file.path(workingFolder,paste(data.type.label,datestring,'.grid.Z',sep=''))
     didFail = tryCatch({utils::download.file(url,des.file.name, quiet = T, mode = "wb")},error = function(cond) {return(TRUE)})
+    if (didFail) {
+      didFail = tryCatch(
+        {
+          message('Http request failed. Trying with a Mozila 5.0 useragent')
+          content <- RCurl::getBinaryURL(url, verbose=FALSE, .opts=list(useragent='Mozila 5.0'))
+          writeBin(content, des.file.name)
+        },
+        error = function(cond) {
+          return(TRUE)
+        }
+      )
+      didFail = 0
+    }
     if (didFail==0) {
 
       displayErrorMessage <- function() {
@@ -69,6 +82,19 @@ download.ASCII.file <- function (url.string, data.type.label,  workingFolder, da
 
     des.file.name = file.path(workingFolder,paste(data.type.label,datestring,'.grid.Z',sep=''))
     didFail = tryCatch({utils::download.file(url,des.file.name, quiet = T)},error = function(cond) {return(TRUE)})
+    if (didFail) {
+      didFail = tryCatch(
+        {
+          message('Http request failed. Trying with a Mozila 5.0 useragent')
+          content <- RCurl::getBinaryURL(url, verbose=FALSE, .opts=list(useragent='Mozila 5.0'))
+          writeBin(content, des.file.name)
+        },
+        error = function(cond) {
+          return(TRUE)
+        }
+      )
+      didFail = 0
+    }
     if (didFail==0) {
       system(paste('znew -f ',des.file.name));
       des.file.name = gsub('.Z', '.gz', des.file.name)

--- a/R/download.ASCII.file.R
+++ b/R/download.ASCII.file.R
@@ -25,8 +25,11 @@ download.ASCII.file <- function (url.string, data.type.label,  workingFolder, da
     des.file.name = file.path(workingFolder,paste(data.type.label,datestring,'.grid.Z',sep=''))
     didFail = tryCatch(
       {
-        content <- RCurl::getBinaryURL(url, verbose=FALSE, .opts=list(useragent='Mozila 5.0'))
-        writeBin(content, des.file.name)
+        # only download the file if the .Z file isn't saved in the working directory
+        if (!file.exists(des.file.name)) {
+          content <- RCurl::getBinaryURL(url, verbose=FALSE, .opts=list(useragent='Mozila 5.0'))
+          writeBin(content, des.file.name)
+        }
       },
       error = function(cond) {
         return(TRUE)
@@ -66,8 +69,8 @@ download.ASCII.file <- function (url.string, data.type.label,  workingFolder, da
           )
         }
       )
-      file.remove(des.file.name)
       if (!is.null(attr(exitMessage,'status'))) {
+        file.remove(des.file.name)
         displayErrorMessage()
       }
 

--- a/R/download.ASCII.file.R
+++ b/R/download.ASCII.file.R
@@ -23,20 +23,16 @@ download.ASCII.file <- function (url.string, data.type.label,  workingFolder, da
   OS <- OS[1]
   if (OS=='Windows') {
     des.file.name = file.path(workingFolder,paste(data.type.label,datestring,'.grid.Z',sep=''))
-    didFail = tryCatch({utils::download.file(url,des.file.name, quiet = T, mode = "wb")},error = function(cond) {return(TRUE)})
-    if (didFail) {
-      didFail = tryCatch(
-        {
-          message('Http request failed. Trying with a Mozila 5.0 useragent')
-          content <- RCurl::getBinaryURL(url, verbose=FALSE, .opts=list(useragent='Mozila 5.0'))
-          writeBin(content, des.file.name)
-        },
-        error = function(cond) {
-          return(TRUE)
-        }
-      )
-      didFail = 0
-    }
+    didFail = tryCatch(
+      {
+        content <- RCurl::getBinaryURL(url, verbose=FALSE, .opts=list(useragent='Mozila 5.0'))
+        writeBin(content, des.file.name)
+      },
+      error = function(cond) {
+        return(TRUE)
+      }
+    )
+    if (length(didFail) == 0) {didFail <- 0}
     if (didFail==0) {
 
       displayErrorMessage <- function() {
@@ -62,7 +58,6 @@ download.ASCII.file <- function (url.string, data.type.label,  workingFolder, da
         error = function(cond) {
           try_again = tryCatch(
             {
-              message('7-zip not found in path, trying default Windows installation location.')
               return(system(paste0('"C:\\Program Files\\7-Zip\\7z.exe" e -aoa -bso0 "',des.file.name, '"', ' -o', workingFolder),intern = T))
             },
             error = function(cond) {
@@ -81,20 +76,16 @@ download.ASCII.file <- function (url.string, data.type.label,  workingFolder, da
   } else {
 
     des.file.name = file.path(workingFolder,paste(data.type.label,datestring,'.grid.Z',sep=''))
-    didFail = tryCatch({utils::download.file(url,des.file.name, quiet = T)},error = function(cond) {return(TRUE)})
-    if (didFail) {
-      didFail = tryCatch(
-        {
-          message('Http request failed. Trying with a Mozila 5.0 useragent')
-          content <- RCurl::getBinaryURL(url, verbose=FALSE, .opts=list(useragent='Mozila 5.0'))
-          writeBin(content, des.file.name)
-        },
-        error = function(cond) {
-          return(TRUE)
-        }
-      )
-      didFail = 0
-    }
+    didFail = tryCatch(
+      {
+        content <- RCurl::getBinaryURL(url, verbose=FALSE, .opts=list(useragent='Mozila 5.0'))
+        writeBin(content, des.file.name)
+      },
+      error = function(cond) {
+        return(TRUE)
+      }
+    )
+    if (length(didFail) == 0) {didFail <- 0}
     if (didFail==0) {
       system(paste('znew -f ',des.file.name));
       des.file.name = gsub('.Z', '.gz', des.file.name)

--- a/R/makeNetCDF_file.R
+++ b/R/makeNetCDF_file.R
@@ -98,6 +98,7 @@ makeNetCDF_file <- function(
     message('Starting to update both netCDF files.')
   } else if (file.exists(ncdfFilename) && !file.exists(ncdfSolarFilename)) {
     message('Starting to update the main climate data netCDF file and will build the solar radiation netcdf file.')
+    doUpdate = TRUE
   } else if (!file.exists(ncdfFilename) && file.exists(ncdfSolarFilename)) {
     message('Starting to update the solar radiation netcdf file and will build the main climate data netcdf file.')
     doUpdate_solar = TRUE;


### PR DESCRIPTION
I noticed AWAPer no longer works with the default way to download files. After reading through the following discussion #23, I implemented the discussed fix and it seems to be working well again.
 
I also corrected how the 7-zip error message is displayed, as it did not display when it could not find 7-zip in the path during testing. 

I added some additional messages, but I am happy to remove those if it is too annoying. 

